### PR TITLE
[FEATURE] make PyProphet an optional dependency

### DIFF
--- a/easypqp/library.py
+++ b/easypqp/library.py
@@ -20,8 +20,11 @@ import statsmodels.api as sm
 from scipy.interpolate import interp1d
 
 # error rate estimation
-from pyprophet.stats import pemp, qvalue, pi0est
-from pyprophet.ipf import compute_model_fdr
+try:
+  from pyprophet.stats import pemp, qvalue, pi0est
+  from pyprophet.ipf import compute_model_fdr
+except ModuleNotFoundError:
+  pass
 
 # plotting
 from scipy.stats import gaussian_kde

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -6,7 +6,10 @@ import pandas as pd
 from shutil import copyfile
 from .convert import conversion
 from .library import generate
-from pyprophet.data_handling import transform_pi0_lambda
+try:
+    from pyprophet.data_handling import transform_pi0_lambda
+except ModuleNotFoundError:
+    transform_pi0_lambda = None
 
 @click.group(chain=True)
 @click.version_option()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     include_package_data=True,
-    install_requires=['Click','numpy','scipy','statsmodels','pandas','biopython','pyprophet','pyopenms','matplotlib','seaborn'],
+    install_requires=['Click','numpy','scipy','statsmodels','pandas','biopython','pyopenms','matplotlib','seaborn'],
     # extras_require={  # Optional
     #     'dev': ['check-manifest'],
     #     'test': ['coverage'],
@@ -46,5 +46,7 @@ setup(
             'easypqp=easypqp.main:cli',
         ],
     },
-    
+    extras_require={
+        'PyProphet': ['pyprophet'],
+    },
 )


### PR DESCRIPTION
PyProphet requires Microsoft Visual C++ to install on Windows.