### PR TITLE
Adaptation for idxml support

### DIFF
--- a/easypqp/convert.py
+++ b/easypqp/convert.py
@@ -266,15 +266,15 @@ class idxml:
                                        'massdiff': float(0),
                                        'precursor_charge': int(p.getHits()[0].getCharge()),
                                        'retention_time': float(p.getRT()),
-                                       'modified_peptide': p.getHits()[0].getSequence().toUniModString(),
-                                       'peptide_sequence': p.getHits()[0].getSequence().toUnmodifiedString(),
+                                       'modified_peptide': p.getHits()[0].getSequence().toUniModString().decode("utf-8"),
+                                       'peptide_sequence': p.getHits()[0].getSequence().toUnmodifiedString().decode("utf-8"),
                                        'modifications': '-',
                                        'nterm_modification': '-',
                                        'cterm_modification': '-',
-                                       'protein_id': ','.join([str(prot.getProteinAccession()) for prot in p.getHits()[0].getPeptideEvidences()]),
+                                       'protein_id': ','.join([prot.getProteinAccession().decode("utf-8") for prot in p.getHits()[0].getPeptideEvidences()]),
                                        'gene_id': '-',
                                        'num_tot_proteins': len([prot.getProteinAccession() for prot in p.getHits()[0].getPeptideEvidences()]),
-                                       'decoy': p.getHits()[0].getMetaValue('target_decoy')==b'decoy'}, **scores})
+                                       'decoy': p.getHits()[0].getMetaValue('target_decoy').decode("utf-8")=='decoy'}, **scores})
 
         df = pd.DataFrame(parsed_peptides)
 

--- a/easypqp/convert.py
+++ b/easypqp/convert.py
@@ -256,7 +256,7 @@ class idxml:
             scores["var_MS:1002252_Comet:XCorr"] = float(p.getHits()[0].getMetaValue('MS:1002252'))
             scores["var_MS:1002253_Comet:DeltCn"] = float(p.getHits()[0].getMetaValue('MS:1002253'))
 
-            #probability
+            #percolator probability
             scores["q_value"] = float(p.getHits()[0].getMetaValue('MS:1001491'))
             scores["pep"] = float(p.getHits()[0].getMetaValue('MS:1001491'))
 
@@ -549,6 +549,8 @@ def conversion(pepxmlfile, spectralfile, unimodfile, exclude_range, max_delta_un
 		print('unknown format of pepxml identification file')
 
 	# Continue if any PSMS are present
+	psms = px.get()
+
 	if psms.shape[0] > 0:
 		run_id = basename_spectralfile(spectralfile)
 		rank = re.compile(r'_rank([0-9]+)\.').search(pathlib.Path(pepxmlfile).name)

--- a/easypqp/library.py
+++ b/easypqp/library.py
@@ -63,37 +63,50 @@ def plot(path, title, targets, decoys):
   plt.savefig(path)
   plt.close()
 
-def peptide_fdr(psms, peptide_fdr_threshold, pi0_lambda, plot_path):
+def peptide_fdr(psms, peptide_fdr_threshold, pi0_lambda, plot_path, nofdr):
   pi0_method = 'bootstrap'
   pi0_smooth_df = 3
   pi0_smooth_log_pi0 = False
   pfdr = False
 
-  peptides = psms.groupby(['modified_peptide','decoy','q_value'])['pp'].max().reset_index()
-  targets = peptides[~peptides['decoy']].copy()
-  decoys = peptides[peptides['decoy']].copy()
 
-  #targets['p_value'] = pemp(targets['pp'], decoys['pp'])
-  #targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
+  if nofdr:
+    peptides = psms.groupby(['modified_peptide','decoy','q_value'])['pp'].max().reset_index()
+    targets = peptides[~peptides['decoy']].copy()
+    decoys = peptides[peptides['decoy']].copy()
 
-  #plot(plot_path, "global peptide scores", targets['pp'], decoys['pp'])
+  else:
+    peptides = psms.groupby(['modified_peptide','decoy'])['pp'].max().reset_index()
+    targets = peptides[~peptides['decoy']].copy()
+    decoys = peptides[peptides['decoy']].copy()
+
+    targets['p_value'] = pemp(targets['pp'], decoys['pp'])
+    targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
+
+    plot(plot_path, "global peptide scores", targets['pp'], decoys['pp'])
   
   return targets[targets['q_value'] < peptide_fdr_threshold]['modified_peptide'], np.min(targets[targets['q_value'] < peptide_fdr_threshold]['pp'])
 
-def protein_fdr(psms, protein_fdr_threshold, pi0_lambda, plot_path):
+def protein_fdr(psms, protein_fdr_threshold, pi0_lambda, plot_path, nofdr):
   pi0_method = 'bootstrap'
   pi0_smooth_df = 3
   pi0_smooth_log_pi0 = False
   pfdr = False
 
-  proteins = psms.groupby(['protein_id','decoy','q_value'])['pp'].max().reset_index()
-  targets = proteins[~proteins['decoy']].copy()
-  decoys = proteins[proteins['decoy']].copy()
+  if nofdr:
+    proteins = psms.groupby(['protein_id','decoy','q_value'])['pp'].max().reset_index()
+    targets = proteins[~proteins['decoy']].copy()
+    decoys = proteins[proteins['decoy']].copy()
 
-  #targets['p_value'] = pemp(targets['pp'], decoys['pp'])
-  #targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
+  else:
+    proteins = psms.groupby(['protein_id','decoy'])['pp'].max().reset_index()  
+    targets = proteins[~proteins['decoy']].copy()
+    decoys = proteins[proteins['decoy']].copy()
 
-  #plot(plot_path, "global protein scores", targets['pp'], decoys['pp'])
+    targets['p_value'] = pemp(targets['pp'], decoys['pp'])
+    targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
+
+    plot(plot_path, "global protein scores", targets['pp'], decoys['pp'])
   
   return targets[targets['q_value'] < protein_fdr_threshold]['protein_id'], np.min(targets[targets['q_value'] < protein_fdr_threshold]['pp'])
 
@@ -135,9 +148,9 @@ def process_psms(psms, psmtsv, peptidetsv, psm_fdr_threshold, peptide_fdr_thresh
       psms['q_value'] = compute_model_fdr(psms['pep'].values)
 
     # Confident peptides and protein in global context
-    peptides, peptide_pp_threshold = peptide_fdr(psms, peptide_fdr_threshold, pi0_lambda, peptide_plot_path)
+    peptides, peptide_pp_threshold = peptide_fdr(psms, peptide_fdr_threshold, pi0_lambda, peptide_plot_path, nofdr)
     click.echo("Info: %s modified peptides identified (q-value < %s; PP threshold = %s)" % (len(peptides), peptide_fdr_threshold, peptide_pp_threshold))
-    proteins, protein_pp_threshold = protein_fdr(psms, protein_fdr_threshold, pi0_lambda, protein_plot_path)
+    proteins, protein_pp_threshold = protein_fdr(psms, protein_fdr_threshold, pi0_lambda, protein_plot_path, nofdr)
     click.echo("Info: %s proteins identified (q-value < %s; PP threshold = %s)" % (len(proteins), protein_fdr_threshold, protein_pp_threshold))
 
     # Filter peptides and proteins
@@ -209,7 +222,7 @@ def remove_rank_suffix(x):
   import re
   return re.compile('(.+?)(?:_rank[0-9]+)?').fullmatch(x).group(1)
 
-def generate(files, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im_referencefile, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_frac, rt_psm_fdr_threshold, im_lowess_frac, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus):
+def generate(files, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im_referencefile, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_frac, rt_psm_fdr_threshold, im_lowess_frac, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus, nofdr):
   # Parse input arguments
   psm_files = []
   spectra = []

--- a/easypqp/library.py
+++ b/easypqp/library.py
@@ -110,7 +110,7 @@ def protein_fdr(psms, protein_fdr_threshold, pi0_lambda, plot_path, nofdr):
   
   return targets[targets['q_value'] < protein_fdr_threshold]['protein_id'], np.min(targets[targets['q_value'] < protein_fdr_threshold]['pp'])
 
-def process_psms(psms, psmtsv, peptidetsv, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, proteotypic):
+def process_psms(psms, psmtsv, peptidetsv, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, proteotypic, nofdr):
   # Append columns
   psms['base_name'] = psms['run_id'].apply(lambda x: os.path.splitext(os.path.basename(x))[0])
 
@@ -258,7 +258,7 @@ def generate(files, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im
   psms['pp'] = 1-psms['pep']
 
   # Process PSMs
-  pepid = process_psms(psms, psmtsv, peptidetsv, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, proteotypic)
+  pepid = process_psms(psms, psmtsv, peptidetsv, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, proteotypic, nofdr)
 
   # Get main path for figures
   main_path = os.path.dirname(os.path.abspath(peptide_plot_path))

--- a/easypqp/library.py
+++ b/easypqp/library.py
@@ -69,14 +69,14 @@ def peptide_fdr(psms, peptide_fdr_threshold, pi0_lambda, plot_path):
   pi0_smooth_log_pi0 = False
   pfdr = False
 
-  peptides = psms.groupby(['modified_peptide','decoy'])['pp'].max().reset_index()
+  peptides = psms.groupby(['modified_peptide','decoy','q_value'])['pp'].max().reset_index()
   targets = peptides[~peptides['decoy']].copy()
   decoys = peptides[peptides['decoy']].copy()
 
-  targets['p_value'] = pemp(targets['pp'], decoys['pp'])
-  targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
+  #targets['p_value'] = pemp(targets['pp'], decoys['pp'])
+  #targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
 
-  plot(plot_path, "global peptide scores", targets['pp'], decoys['pp'])
+  #plot(plot_path, "global peptide scores", targets['pp'], decoys['pp'])
   
   return targets[targets['q_value'] < peptide_fdr_threshold]['modified_peptide'], np.min(targets[targets['q_value'] < peptide_fdr_threshold]['pp'])
 
@@ -86,14 +86,14 @@ def protein_fdr(psms, protein_fdr_threshold, pi0_lambda, plot_path):
   pi0_smooth_log_pi0 = False
   pfdr = False
 
-  proteins = psms.groupby(['protein_id','decoy'])['pp'].max().reset_index()
+  proteins = psms.groupby(['protein_id','decoy','q_value'])['pp'].max().reset_index()
   targets = proteins[~proteins['decoy']].copy()
   decoys = proteins[proteins['decoy']].copy()
 
-  targets['p_value'] = pemp(targets['pp'], decoys['pp'])
-  targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
+  #targets['p_value'] = pemp(targets['pp'], decoys['pp'])
+  #targets['q_value'] = qvalue(targets['p_value'], pi0est(targets['p_value'], pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)['pi0'], pfdr)
 
-  plot(plot_path, "global protein scores", targets['pp'], decoys['pp'])
+  #plot(plot_path, "global protein scores", targets['pp'], decoys['pp'])
   
   return targets[targets['q_value'] < protein_fdr_threshold]['protein_id'], np.min(targets[targets['q_value'] < protein_fdr_threshold]['pp'])
 

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -84,12 +84,13 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
 @click.option('--min_peptides', default=5, show_default=True, type=int, help='Minimum peptides required for successful alignment.')
 @click.option('--proteotypic/--no-proteotypic', show_default=True, default=True, help='Use only proteotypic, unique, non-shared peptides.')
 @click.option('--consensus/--no-consensus', show_default=True, default=True, help='Generate consensus instead of best replicate spectra.')
-def library(infiles, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im_referencefile, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus):
+@click.option('--nofdr/--no-fdr-filtering', show_default=True, default=False, help='Do not reassess or filter by FDR, as library was already provided using customized FDR filtering.')
+def library(infiles, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im_referencefile, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus, nofdr):
     """
     Generate EasyPQP library
     """
 
-    generate(infiles, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im_referencefile, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus)
+    generate(infiles, outfile, psmtsv, peptidetsv, rt_referencefile, rt_filter, im_referencefile, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus, nofdr)
     click.echo("Info: Library successfully generated.")
 
 # EasyPQP Reduce


### PR DESCRIPTION
Hi @grosenberger ,

I just wanted to show you the main changes I did so far, in order to integrate idXML files.

- I guess it is quite error prone in this state, as it would only work with comet/percolator analyzed idXMLs.

 - Moreover, I had to "out-comment" the steps in the peptide/protein fdr calculation in library.py in order to get it run through. I was planing to input already processed idXMLs that were previously filtered based on peptide_fdr and don't contain decoy hits anymore.

Do you think if we would add another flag in the main / and or description this could be integrated in your master?