### PR TITLE
Feature/filter unimod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 EasyPQP: Simple library generation for OpenSWATH
 ================================================
 
-EasyPQP is a Python package that provides simplified and fast peptide query parameter generation for OpenSWATH. It can process input from MSFragger or other database search engines in pepXML format. Statistical validation can be conducted either using PyProphet or PeptideProphet/iProphet. Retention times are calibrated using an internal or external standard. In addition to a cumulative library, run-specific libraries are generated for non-linear RT alignment in OpenSWATH.
+EasyPQP is a Python package that provides simplified and fast peptide query parameter generation for OpenSWATH. It can process input from MSFragger or other database search engines in pepXML format. Statistical validation can be conducted either using PyProphet or PeptideProphet/iProphet. Retention times are calibrated using an internal or external standard. In addition to a cumulative library, run-specific libraries are generated for non-linear RT alignment in OpenSWATH. For generation of PTM specific libraries that utilizes a unimod.xml database, you can further restrict the unimod.xml database file for modifications and site-specificities of interest.
 
 Installation
 ============
@@ -28,6 +28,8 @@ or:
 ````
    $ easypqp convert --help
    $ easypqp library --help
+   $ easypqp reduce --help
+   $ easypqp filter-unimod --help
 ````
 
 Docker

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -172,14 +172,23 @@ def reduce(infile, outfile, bins, peptides):
 
     click.echo("Info: Library successfully processed and stored in %s." % outfile)
 
+# Parameter transformation functions
+def transform_comma_string_to_list(ctx, param, value):
+    if value is not None:
+        str_list = value.split(",")
+        return str_list
+    else:
+        return None 
 
 # EasyPQP UniMod Database Filtering
 @cli.command()
 @click.option('--in', 'infile', required=False, default=pkg_unimod_db, show_default=True, type=click.Path(exists=True), help='Input UniMod XML file.')
 @click.option('--out', 'outfile', required=False, default="unimod_ipf.xml", show_default=True, type=click.Path(exists=False), help='Output Filtered UniMod XML file.')
-@click.option('--ids', 'accession_ids', default='[1,2,4,5,7,21,26,27,28,34,35,36,40,121,122,259,267,299,354]', show_default=True, cls=PythonLiteralOption, help='UniMod record ids to filter for, i.e. [1,4,21].')
-def filter_unimod(infile, outfile, accession_ids):
+@click.option('--ids', 'accession_ids', default='1,2,4,5,7,21,26,27,28,34,35,36,40,121,122,259,267,299,354', show_default=True, type=str, help='UniMod record ids to filter for, i.e. [1,2,4,21].', callback=transform_comma_string_to_list)
+@click.option('--sites', 'site_specificity', default=None, show_default=True, type=str, help="""Optional further restriction for specificity, i.e. [n,],M,nK[,QN,STY,*,*,*,EDcRK,WM,RK,Y,K,[TKnS,K,R,EK,Y]. Ensure, you match the sites you want to restrict per unimod.\b\n\nFor example, if --ids=1,21,35, then you should have the following for --sites=n,STY,M. This will restrict acetylation for any N-Term, phosphorylation for serine, threonine, and tyrosine, and oxidation for methionine.
+\b\n\nValid Sites:\n\n* - wildcard, will not restrict for any specificty for corresponding UniMod entry.\n\n[ - Protein N-Term\n\n] - Protein C-Term\n\nn - Any N-Term\n\nc - Any C-Term\n\nAmino Acid Letter - A valid amino acid one letter code.\n\n""", callback=transform_comma_string_to_list)
+def filter_unimod(infile, outfile, accession_ids, site_specificity):
     """
     Reduce UniMod XML Database file
     """
-    unimod_filter(infile, outfile, accession_ids)
+    unimod_filter(infile, outfile, accession_ids, site_specificity)

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -184,7 +184,7 @@ def transform_comma_string_to_list(ctx, param, value):
 @cli.command()
 @click.option('--in', 'infile', required=False, default=pkg_unimod_db, show_default=True, type=click.Path(exists=True), help='Input UniMod XML file.')
 @click.option('--out', 'outfile', required=False, default="unimod_ipf.xml", show_default=True, type=click.Path(exists=False), help='Output Filtered UniMod XML file.')
-@click.option('--ids', 'accession_ids', default='1,2,4,5,7,21,26,27,28,34,35,36,40,121,122,259,267,299,354', show_default=True, type=str, help='UniMod record ids to filter for, i.e. [1,2,4,21].', callback=transform_comma_string_to_list)
+@click.option('--ids', 'accession_ids', default='1,2,4,5,7,21,26,27,28,34,35,36,40,121,122,259,267,299,354', show_default=True, type=str, help='UniMod record ids to filter for, i.e. 1,2,4,21.', callback=transform_comma_string_to_list)
 @click.option('--sites', 'site_specificity', default=None, show_default=True, type=str, help="""Optional further restriction for specificity, i.e. [n,],M,nK[,QN,STY,*,*,*,EDcRK,WM,RK,Y,K,[TKnS,K,R,EK,Y]. Ensure, you match the sites you want to restrict per unimod.\b\n\nFor example, if --ids=1,21,35, then you should have the following for --sites=n,STY,M. This will restrict acetylation for any N-Term, phosphorylation for serine, threonine, and tyrosine, and oxidation for methionine.
 \b\n\nValid Sites:\n\n* - wildcard, will not restrict for any specificty for corresponding UniMod entry.\n\n[ - Protein N-Term\n\n] - Protein C-Term\n\nn - Any N-Term\n\nc - Any C-Term\n\nAmino Acid Letter - A valid amino acid one letter code.\n\n""", callback=transform_comma_string_to_list)
 def filter_unimod(infile, outfile, accession_ids, site_specificity):

--- a/easypqp/unimoddb.py
+++ b/easypqp/unimoddb.py
@@ -1,10 +1,61 @@
 import click
+from tqdm import tqdm
 
 # Unimod parsing
 import xml.etree.cElementTree as ET
-from xml.etree.cElementTree import iterparse
 
-def unimod_filter(unimod_file, out_file, accession_ids):
+
+def site_validation(site_input):
+    """
+    Perform a check to ensure inputs are valid
+    Arguments:
+        site_input: (list) list of amino acid residues, or terminal notation, or wild card notation (*).
+    Returns:
+        Nothing is returned. An error is raised if the input contains a non-valid site.
+    """
+    acceptable_sites = ["A", "R", "N", "D", "C", "E", "Q", "G", "H", "I", "L", "K", "M", "F", "P", "S", "T", "W", "Y", "V", 'U', 'O', '[', ']', 'n', 'c', '*']
+    site_check = [site not in acceptable_sites for site in site_input]
+    if any(site_check):
+        raise click.ClickException( f"Incorrect site specificity input, site(s) {', '.join([i for (i, v) in zip(site_input, site_check) if v])} is not valid. Acceptable sites: {', '.join(acceptable_sites)}")
+
+def site_specificity_transform(site_input):
+    """
+    Transform input site to return the site and position. Transforms terminal notation to site notation in unimod.xml and whether its any terminal site or a protein terminal site.
+    Arguments:
+        site_input: (list) list of amino acid residues, or terminal notation, or wild card notation (*).
+    Returns:
+        Returns a tuple of list of sites and list of positions
+    """
+    # Site and Position Mapping
+    terminal_map = {'[':'N-term', ']':'C-term', 'n':'N-term', 'c':'C-term'}
+    site_position_map = {'[':'Protein N-term', ']':'Protein C-term', 'n':'Any N-term', 'c':'Any C-term'}
+    # Split sites
+    site_input = [site for site in site_input]
+    site_validation(site_input)
+    sites=[]; positions=[]
+    for site in site_input:
+        if site in terminal_map.keys():
+            sites.append(terminal_map[site])
+            positions.append(site_position_map[site])
+        elif site=="*":
+            sites.append("*")
+            positions.append("*")
+        else:
+            sites.append(site)
+            positions.append("Anywhere")
+    return sites, positions
+
+def unimod_filter(unimod_file, out_file, accession_ids, site_specificity):
+    """
+    Filter an input unimod to restrict for specific modifications and site specificities
+    Arguments:
+        unimod_file: (str) path/filename of input unimod.xml file.
+        out_file: (str) path/filename to write out new filtered unimod.xml file
+        accession_ids: (list) list of unimod accession ids to restrict for. i.e. ['1','21','35]
+        site_specificity: (list) list of site specificties to further restrict corresponding unimod for. i.e. ['n','STY','M], will restrict acetylation for any N-Term, phosphorylation for serine, threonine, and tyrosine, and oxidation for methionine.
+    Returns:
+        Nothing is returned. The restricted unimod database is written to the out_file.
+    """
     # Register Namespace
     ET.register_namespace('umod', 'http://www.unimod.org/xmlns/schema/unimod_2')
 
@@ -26,11 +77,31 @@ def unimod_filter(unimod_file, out_file, accession_ids):
     # Append desired modifications
     mod_entries = root.findall('umod:modifications', ns)[0]
     mod_out = ET.Element(mod_entries.tag, mod_entries.attrib)
-    for record_id in accession_ids:
-        # print(record_id)
+    i=0
+    pbar = tqdm(accession_ids)
+    pbar_desc = "INFO: Restricting"
+    for record_id in pbar:
         add_unimod_entry = mod_entries.findall(f"./umod:mod/[@record_id='{record_id}']", ns)[0]
-        click.echo(f"INFO: Appending to filtered unimod XML - title={add_unimod_entry.attrib.get('title')} with record_id={add_unimod_entry.attrib.get('record_id')}")
+        if site_specificity is not None:
+            site, position = site_specificity_transform(site_specificity[i])
+            # Update progess bar description
+            pbar_desc = pbar_desc + f"..{add_unimod_entry.attrib.get('title')}({','.join(site)})"
+            pbar.set_description(pbar_desc)
+            if site != "*":
+                for unimod_site in add_unimod_entry.findall(f"./umod:specificity", ns):
+                    if unimod_site.attrib['site'] in site and unimod_site.attrib['position'] in position:
+                        # If current specificity element is a requested one, continue on
+                        continue
+                    else:
+                        # Remove specificities that do not match requested specificities
+                        add_unimod_entry.remove(unimod_site)
+        else:
+            # Update progess bar description
+            pbar_desc = pbar_desc + f"..{add_unimod_entry.attrib.get('title')}"
+            pbar.set_description(pbar_desc)
+        # click.echo(f"INFO: Appending to filtered unimod XML - title={add_unimod_entry.attrib.get('title')} with record_id={add_unimod_entry.attrib.get('record_id')}")
         mod_out.append( add_unimod_entry )
+        i+=1
     root_out.append(mod_out)
 
     # Append amino acids

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     include_package_data=True,
-    install_requires=['Click>=8.0.0','numpy','scipy','scikit-learn','statsmodels','pandas>=1.1.0','biopython','pyopenms>=2.6.0','matplotlib','seaborn'],
+    install_requires=['Click>=8.0.0','numpy','scipy','scikit-learn','statsmodels','pandas>=1.1.0','biopython','pyopenms>=2.6.0','matplotlib','seaborn', 'tqdm'],
     # extras_require={  # Optional
     #     'dev': ['check-manifest'],
     #     'test': ['coverage'],


### PR DESCRIPTION
I added additional capability to further restrict for site specificity as discussed in PR https://github.com/grosenberger/easypqp/pull/87#issuecomment-1173512166.

I added an additional dependency `tqdm` just for some progress bar console logging.

# Example
```
$ easypqp filter-unimod --help
Usage: easypqp filter-unimod [OPTIONS]

  Reduce UniMod XML Database file

Options:
  --in PATH     Input UniMod XML file.  [default:
                /home/justincsing/anaconda3/envs/py39/lib/python3.9/site-
                packages/easypqp-0.1.30-py3.9.egg/easypqp/data/unimod.xml]
  --out PATH    Output Filtered UniMod XML file.  [default: unimod_ipf.xml]
  --ids TEXT    UniMod record ids to filter for, i.e. 1,2,4,21.  [default:
                1,2,4,5,7,21,26,27,28,34,35,36,40,121,122,259,267,299,354]
  --sites TEXT  Optional further restriction for specificity, i.e.
                [n,],M,nK[,QN,STY,*,*,*,EDcRK,WM,RK,Y,K,[TKnS,K,R,EK,Y].
                Ensure, you match the sites you want to restrict per unimod.
                
                For example, if --ids=1,21,35, then you should have the
                following for --sites=n,STY,M. This will restrict acetylation
                for any N-Term, phosphorylation for serine, threonine, and
                tyrosine, and oxidation for methionine. 
                
                Valid Sites:
                
                * - wildcard, will not restrict for any specificty for
                corresponding UniMod entry.
                
                [ - Protein N-Term
                
                ] - Protein C-Term
                
                n - Any N-Term
                
                c - Any C-Term
                
                Amino Acid Letter - A valid amino acid one letter code.
  --help        Show this message and exit.
```

```
$ easypqp filter-unimod --out unimod_ipf.xml --ids 1,2,4,21,35 
INFO: Loading XML data from /home/justincsing/anaconda3/envs/py39/lib/python3.9/site-packages/easypqp-0.1.30-py3.9.egg/easypqp/data/unimod.xml
INFO: Restricting..Acetyl..Amidated..Carbamidomethyl..Phospho..Oxidation: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 2406.37it/s]
INFO: Writing out filtered unimod XML file to unimod_ipf.xml
```

```
$ easypqp filter-unimod --out unimod_ipf.xml --ids 1,2,4,21,35 --sites n,],C,STY,M
INFO: Loading XML data from /home/justincsing/anaconda3/envs/py39/lib/python3.9/site-packages/easypqp-0.1.30-py3.9.egg/easypqp/data/unimod.xml
INFO: Restricting..Acetyl(N-term)..Amidated(C-term)..Carbamidomethyl(C)..Phospho(S,T,Y)..Oxidation(M): 100%|█████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 2404.44it/s]
INFO: Writing out filtered unimod XML file to unimod_ipf.xml

```