### PR TITLE
Speed and memory optimization for the FragPipe DIA workflow.

### DIFF
--- a/easypqp/convert.py
+++ b/easypqp/convert.py
@@ -1,6 +1,7 @@
 import itertools
 import pathlib
 import time
+from .util import timestamped_echo
 import numpy as np
 import pandas as pd
 import os
@@ -444,9 +445,8 @@ def read_mzml_or_mzxml_impl(path, psms, theoretical, max_delta_ppm, filetype):
 	for scan_id, modified_peptide, precursor_charge in psms.itertuples(index=None):
 		peaks_list.append(psm_df(input_map, theoretical, max_delta_ppm, scan_id, modified_peptide, precursor_charge))
 
-	click.echo("Info: Got %d PSMs in %.2f minutes" % (len(peaks_list), (time.time() - start_time) / 60.0))
-	click.echo("Info: Generating Transitions...")
-	start_time = time.time()
+	timestamped_echo("Info: Got %d PSMs" % len(peaks_list))
+	timestamped_echo("Info: Generating Transitions...")
 
 	if len(peaks_list) > 0:
 		reps = np.array([e[0] for e in peaks_list])
@@ -462,7 +462,7 @@ def read_mzml_or_mzxml_impl(path, psms, theoretical, max_delta_ppm, filetype):
 	else:
 		transitions = pd.DataFrame({'scan_id': [], 'modified_peptide': [], 'precursor_charge': [], 'precursor_mz': [], 'fragment': [], 'product_mz': [], 'intensity': []})
 
-	click.echo("Info: Generated %d transitions in %.2f minutes" % (len(transitions), (time.time() - start_time) / 60.0))
+	timestamped_echo("Info: Generated %d transitions" % len(transitions))
 
 	return(transitions)
 
@@ -641,7 +641,7 @@ def generate_ionseries(peptide_sequence, precursor_charge, fragment_charges=[1,2
 def conversion(pepxmlfile, spectralfile, unimodfile, exclude_range, max_delta_unimod, max_delta_ppm, enable_unannotated, enable_massdiff, fragment_types, fragment_charges, enable_specific_losses, enable_unspecific_losses, max_psm_pep):
 	# Parse basename
 	base_name = basename_spectralfile(spectralfile)
-	click.echo("Info: Parsing run %s." % base_name)
+	timestamped_echo("Info: Parsing run %s." % base_name)
 
 	# Initialize UniMod
 	um = unimod(unimodfile, max_delta_unimod)

--- a/easypqp/convert.py
+++ b/easypqp/convert.py
@@ -439,7 +439,7 @@ def read_mzml_or_mzxml_impl(path, psms, theoretical, max_delta_ppm, filetype):
 	click.echo("Info: Collecting PSMs...")
 	start_time = time.time()
 
-	input_map = {get_scan(e.getNativeID(), idx + 1): e for idx, e in enumerate(input_map.getSpectra())}
+	input_map = {get_scan(e.getNativeID(), idx + 1): e for idx, e in enumerate(input_map)}
 	peaks_list = []
 	for scan_id, modified_peptide, precursor_charge in psms.itertuples(index=None):
 		peaks_list.append(psm_df(input_map, theoretical, max_delta_ppm, scan_id, modified_peptide, precursor_charge))

--- a/easypqp/convert.py
+++ b/easypqp/convert.py
@@ -441,9 +441,17 @@ def read_mzml_or_mzxml_impl(input_map, psms, theoretical, max_delta_ppm, filetyp
 	start_time = time.time()
 
 	input_map = {get_scan(getNativeID, idx + 1): e for idx, (getNativeID, e) in enumerate(input_map)}
-	peaks_list = []
-	for scan_id, modified_peptide, precursor_charge in psms.itertuples(index=None):
-		peaks_list.append(psm_df(input_map, theoretical, max_delta_ppm, scan_id, modified_peptide, precursor_charge))
+	import concurrent.futures
+	nthreads = min(os.cpu_count(), 5)
+	def f(psms):
+		peaks_list = []
+		for scan_id, modified_peptide, precursor_charge in psms.itertuples(index=None):
+			peaks_list.append(
+				psm_df(input_map, theoretical, max_delta_ppm, scan_id, modified_peptide, precursor_charge))
+		return peaks_list
+	with concurrent.futures.ThreadPoolExecutor(nthreads) as exe:
+		l = exe.map(f, np.array_split(psms, nthreads))
+	peaks_list = sum(l, [])
 
 	timestamped_echo("Info: Got %d PSMs" % len(peaks_list))
 	timestamped_echo("Info: Generating Transitions...")
@@ -529,7 +537,7 @@ def psm_df(input_map, theoretical, max_delta_ppm, scan_id, modified_peptide, pre
 
 	spectrum = input_map[scan_id]
 
-	fragments, product_mzs, intensities = annotate_mass_spectrum(ionseries, max_delta_ppm, spectrum)
+	fragments, product_mzs, intensities = annotate_mass_spectrum_numba(ionseries, max_delta_ppm, spectrum)
 	# Baseline normalization to highest annotated peak
 	max_intensity = np.amax(intensities, initial=0.0)
 	if max_intensity > 0:
@@ -577,6 +585,27 @@ def annotate_mass_spectrum(ionseries, max_delta_ppm, spectrum):
 	idx = ppms[idx_mask].argmin(1)
 	return ions[idx], ion_masses[idx], intensities0[idx_mask]
 
+import numba
+@numba.jit(nopython=True, nogil=True, fastmath=True)
+def annotate_mass_spectrum_numba(ionseries, max_delta_ppm, spectrum):
+	top_delta = 30
+	ions, ion_masses = ionseries
+	mzs0, intensities0 = spectrum
+	idx_ions = np.empty_like(intensities0, dtype=np.uint32)
+	idx_peaks = np.zeros_like(intensities0, dtype=np.bool_)
+	for si, mz in enumerate(mzs0):
+		min_ion_idx = -1
+		min_ppm = top_delta
+		for ii, ion_mass in enumerate(ion_masses):
+			ppm = np.abs(mz - ion_mass) / ion_mass * 1e6
+			if ppm < min(max_delta_ppm, top_delta):
+				if ppm < min_ppm:
+					min_ppm = ppm
+					min_ion_idx = ii
+		if min_ion_idx != -1:
+			idx_ions[si] = min_ion_idx
+			idx_peaks[si] = True
+	return ions[idx_ions[idx_peaks]], ion_masses[idx_ions[idx_peaks]], intensities0[idx_peaks]
 
 
 def generate_ionseries(peptide_sequence, precursor_charge, fragment_charges=[1,2,3,4], fragment_types=['b','y'], enable_specific_losses = False, enable_unspecific_losses = False):

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -56,9 +56,8 @@ class PythonLiteralOption(click.Option):
 @click.option('--fragment_charges', default='[1,2,3,4]', show_default=True, cls=PythonLiteralOption, help='Allowed fragment ion charges.')
 @click.option('--enable_specific_losses/--no-enable_specific_losses', default=False, show_default=True, help='Enable specific fragment ion losses.')
 @click.option('--enable_unspecific_losses/--no-enable_unspecific_losses', default=False, show_default=True, help='Enable unspecific fragment ion losses.')
-@click.option('--subsample_fraction', default=1.0, show_default=True, type=float, help='Data fraction used for subsampling.')
 @click.option('--max_psm_pep', default=0.5, show_default=True, type=float, help='Maximum posterior error probability (PEP) for a PSM')
-def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_range_str, max_delta_unimod, max_delta_ppm, enable_unannotated, enable_massdiff, fragment_types, fragment_charges, enable_specific_losses, enable_unspecific_losses, subsample_fraction, max_psm_pep):
+def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_range_str, max_delta_unimod, max_delta_ppm, enable_unannotated, enable_massdiff, fragment_types, fragment_charges, enable_specific_losses, enable_unspecific_losses, max_psm_pep):
     """
     Convert pepXML files for EasyPQP
     """

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -1,7 +1,7 @@
 import ast
 from .util import timestamped_echo
 import time
-import importlib_resources as pkg_resources
+import importlib.resources as pkg_resources
 import click
 import sqlite3
 import pandas as pd

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -1,5 +1,5 @@
 import ast
-from email.policy import default
+import re
 import time
 import pkg_resources
 import click
@@ -42,7 +42,7 @@ class PythonLiteralOption(click.Option):
 
 # EasyPQP Convert
 @cli.command()
-@click.option('--pepxml', 'pepxmlfile', required=True, type=click.Path(exists=True), help='The input MSFragger TSV file.')
+@click.option('--pepxml', 'pepxmlfile', required=True, type=click.Path(exists=False), help='The input interact-*.pep.xml file or a list of interact-*.pep.xml files.')
 @click.option('--spectra', 'spectralfile', required=True, type=click.Path(exists=True), help='The input mzXML or MGF (timsTOF only) file.')
 @click.option('--unimod', 'unimodfile', required=False, type=click.Path(exists=True), help='The input UniMod XML file.')
 @click.option('--psms', 'psmsfile', required=False, type=click.Path(exists=False), help='Output PSMs file.')
@@ -63,6 +63,15 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
     """
 
     start_time = time.time()
+
+    pepxmlfile_list = []
+    if pepxmlfile.endswith(".pep.xml"):
+        pepxmlfile_list.append(pepxmlfile)
+    elif pepxmlfile.startswith("[") and pepxmlfile.endswith("]"):
+        pepxmlfile_list = ast.literal_eval(pepxmlfile)
+    else:
+        click.echo("Error: Invalid pepXML file name.")
+        return 1
 
     if unimodfile is None:
         unimodfile = pkg_resources.resource_filename('easypqp', 'data/unimod.xml')

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -1,5 +1,5 @@
 import ast
-import re
+from .util import timestamped_echo
 import time
 import pkg_resources
 import click
@@ -70,7 +70,7 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
     elif pepxmlfile.startswith("[") and pepxmlfile.endswith("]"):
         pepxmlfile_list = ast.literal_eval(pepxmlfile)
     else:
-        click.echo("Error: Invalid pepXML file name.")
+        timestamped_echo("Error: Invalid pepXML file name.")
         return 1
 
     if unimodfile is None:
@@ -85,16 +85,16 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
     temp = exclude_range_str.split(',')
     exclude_range = [float(temp[0]), float(temp[1])]
 
-    click.echo("Info: Converting %s." % pepxmlfile)
+    timestamped_echo("Info: Converting %s." % pepxmlfile)
     psms, peaks = conversion(pepxmlfile, spectralfile, unimodfile, exclude_range, max_delta_unimod, max_delta_ppm, enable_unannotated, enable_massdiff, fragment_types, fragment_charges, enable_specific_losses, enable_unspecific_losses, max_psm_pep)
 
     psms.to_pickle(psmsfile)
-    click.echo("Info: PSMs successfully converted and stored in %s." % psmsfile)
+    timestamped_echo("Info: PSMs successfully converted and stored in %s." % psmsfile)
 
     peaks.to_pickle(peaksfile)
-    click.echo("Info: Peaks successfully converted and stored in %s." % peaksfile)
+    timestamped_echo("Info: Peaks successfully converted and stored in %s." % peaksfile)
 
-    click.echo("Info: Total elapsed time %.2f minutes." % ((time.time() - start_time) / 60.0))
+    timestamped_echo("Info: Total elapsed time %.2f minutes." % ((time.time() - start_time) / 60.0))
 
 # EasyPQP Library
 @cli.command()
@@ -132,8 +132,8 @@ def library(infiles, outfile, psmtsv, peptidetsv, perform_rt_calibration, rt_ref
     start_time = time.time()
 
     generate(infiles, outfile, psmtsv, peptidetsv, perform_rt_calibration, rt_referencefile, rt_reference_run_path, rt_filter, perform_im_calibration, im_referencefile, im_reference_run_path, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus, nofdr)
-    click.echo("Info: Library successfully generated.")
-    click.echo("Info: Total elapsed time: %.2f seconds." % (time.time() - start_time))
+    timestamped_echo("Info: Library successfully generated.")
+    timestamped_echo("Info: Total elapsed time: %.2f seconds." % (time.time() - start_time))
 
 # EasyPQP Reduce
 @cli.command()
@@ -188,7 +188,7 @@ def reduce(infile, outfile, bins, peptides):
     # Close connection to file
     con.close()
 
-    click.echo("Info: Library successfully processed and stored in %s." % outfile)
+    timestamped_echo("Info: Library successfully processed and stored in %s." % outfile)
 
 # Parameter transformation functions
 def transform_comma_string_to_list(ctx, param, value):

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -133,7 +133,7 @@ def library(infiles, outfile, psmtsv, peptidetsv, perform_rt_calibration, rt_ref
 
     generate(infiles, outfile, psmtsv, peptidetsv, perform_rt_calibration, rt_referencefile, rt_reference_run_path, rt_filter, perform_im_calibration, im_referencefile, im_reference_run_path, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus, nofdr)
     timestamped_echo("Info: Library successfully generated.")
-    timestamped_echo("Info: Total elapsed time: %.2f seconds." % (time.time() - start_time))
+    timestamped_echo("Info: Total elapsed time: %.2f minutes." % ((time.time() - start_time) / 60.0))
 
 # EasyPQP Reduce
 @cli.command()

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -85,8 +85,8 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
     temp = exclude_range_str.split(',')
     exclude_range = [float(temp[0]), float(temp[1])]
 
-    timestamped_echo("Info: Converting %s." % pepxmlfile)
-    psms, peaks = conversion(pepxmlfile, spectralfile, unimodfile, exclude_range, max_delta_unimod, max_delta_ppm, enable_unannotated, enable_massdiff, fragment_types, fragment_charges, enable_specific_losses, enable_unspecific_losses, max_psm_pep)
+    timestamped_echo("Info: Converting %s." % pepxmlfile_list)
+    psms, peaks = conversion(pepxmlfile_list, spectralfile, unimodfile, exclude_range, max_delta_unimod, max_delta_ppm, enable_unannotated, enable_massdiff, fragment_types, fragment_charges, enable_specific_losses, enable_unspecific_losses, max_psm_pep)
 
     psms.to_pickle(psmsfile)
     timestamped_echo("Info: PSMs successfully converted and stored in %s." % psmsfile)

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -1,6 +1,6 @@
 import ast
 from email.policy import default
-import os
+import time
 import pkg_resources
 import click
 import sqlite3
@@ -63,6 +63,8 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
     Convert pepXML files for EasyPQP
     """
 
+    start_time = time.time()
+
     if unimodfile is None:
         unimodfile = pkg_resources.resource_filename('easypqp', 'data/unimod.xml')
 
@@ -83,6 +85,8 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
 
     peaks.to_pickle(peaksfile)
     click.echo("Info: Peaks successfully converted and stored in %s." % peaksfile)
+
+    click.echo("Info: Total elapsed time %.2f minutes." % ((time.time() - start_time) / 60.0))
 
 # EasyPQP Library
 @cli.command()
@@ -117,8 +121,11 @@ def library(infiles, outfile, psmtsv, peptidetsv, perform_rt_calibration, rt_ref
     Generate EasyPQP library
     """
 
+    start_time = time.time()
+
     generate(infiles, outfile, psmtsv, peptidetsv, perform_rt_calibration, rt_referencefile, rt_reference_run_path, rt_filter, perform_im_calibration, im_referencefile, im_reference_run_path, im_filter, psm_fdr_threshold, peptide_fdr_threshold, protein_fdr_threshold, rt_lowess_fraction, rt_psm_fdr_threshold, im_lowess_fraction, im_psm_fdr_threshold, pi0_lambda, peptide_plot_path, protein_plot_path, min_peptides, proteotypic, consensus, nofdr)
     click.echo("Info: Library successfully generated.")
+    click.echo("Info: Total elapsed time: %.2f seconds." % (time.time() - start_time))
 
 # EasyPQP Reduce
 @cli.command()

--- a/easypqp/main.py
+++ b/easypqp/main.py
@@ -1,7 +1,7 @@
 import ast
 from .util import timestamped_echo
 import time
-import pkg_resources
+import importlib_resources as pkg_resources
 import click
 import sqlite3
 import pandas as pd
@@ -74,7 +74,7 @@ def convert(pepxmlfile, spectralfile, unimodfile, psmsfile, peaksfile, exclude_r
         return 1
 
     if unimodfile is None:
-        unimodfile = pkg_resources.resource_filename('easypqp', 'data/unimod.xml')
+        unimodfile = str(pkg_resources.files('easypqp').joinpath('data/unimod.xml'))
 
     run_id = basename_spectralfile(spectralfile)
     if psmsfile is None:

--- a/easypqp/util.py
+++ b/easypqp/util.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+import click
+
+
+def timestamped_echo(message):
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    click.echo(f"{timestamp} - {message}")

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     include_package_data=True,
-    install_requires=['Click>=8.0.0','numpy','scipy','scikit-learn','statsmodels','pandas>=1.1.0','biopython','pyopenms>=2.6.0','matplotlib','seaborn', 'tqdm'],
+    install_requires=['numba','Click>=8.0.0','numpy','scipy','scikit-learn','statsmodels','pandas>=1.1.0','biopython','pyopenms>=2.6.0','matplotlib','seaborn', 'tqdm'],
     # extras_require={  # Optional
     #     'dev': ['check-manifest'],
     #     'test': ['coverage'],


### PR DESCRIPTION
1. Significantly reduce the runtime and memory footprint of the `convert` command for the DIA data.
2. Add timestamp to the printed log messages.
3. Replace the deprecated  `pkg_resources` package with the `importlib.resources`.

Best,

Fengchao